### PR TITLE
Reject duplicate token IDs in NAV input

### DIFF
--- a/src/accountants/PanopticVaultAccountant.sol
+++ b/src/accountants/PanopticVaultAccountant.sol
@@ -183,9 +183,14 @@ contract PanopticVaultAccountant is Ownable {
 
                 uint256 numLegs;
                 for (uint256 j = 0; j < tokenIds[i].length; j++) {
+                    TokenId _tokenId = tokenIds[i][j];
+                    for (uint256 k = 0; k < j; k++) {
+                        if (TokenId.unwrap(_tokenId) == TokenId.unwrap(tokenIds[i][k]))
+                            revert IncorrectPositionList();
+                    }
+
                     uint128 positionSize = uint128(PositionBalance.unwrap(positionBalanceArray[j]));
                     if (positionSize == 0) revert IncorrectPositionList();
-                    TokenId _tokenId = tokenIds[i][j];
                     uint256 positionLegs = _tokenId.countLegs();
 
                     for (uint256 k = 0; k < positionLegs; k++) {

--- a/test/PanopticVaultAccountant.t.sol
+++ b/test/PanopticVaultAccountant.t.sol
@@ -2062,6 +2062,30 @@ contract PanopticVaultAccountantTest is Test {
         accountant.computeNAV(vault, address(underlyingToken), managerInput);
     }
 
+    function test_computeNAV_revert_duplicateTokenId() public {
+        PanopticVaultAccountant.PoolInfo[] memory pools = createDefaultPools();
+        accountant.updateHashes(vault, pools, new IERC4626[](0));
+
+        setupBasicScenario();
+
+        mockPool.setNumberOfLegs(vault, 2);
+        PositionBalance[] memory positions = new PositionBalance[](2);
+        positions[0] = PositionBalance.wrap(100);
+        positions[1] = PositionBalance.wrap(100);
+        mockPool.setMockPositionBalanceArray(positions);
+
+        TokenId duplicateTokenId = createOutOfRangeTokenId(TWAP_TICK, true, false);
+        TokenId[][] memory tokenIds = new TokenId[][](1);
+        tokenIds[0] = new TokenId[](2);
+        tokenIds[0][0] = duplicateTokenId;
+        tokenIds[0][1] = duplicateTokenId;
+
+        bytes memory managerInput = createManagerInput(pools, tokenIds);
+
+        vm.expectRevert(PanopticVaultAccountant.IncorrectPositionList.selector);
+        accountant.computeNAV(vault, address(underlyingToken), managerInput);
+    }
+
     /*//////////////////////////////////////////////////////////////
                         BOUNDARY CONDITION TESTS
     //////////////////////////////////////////////////////////////*/


### PR DESCRIPTION
## Summary
- Reject duplicate TokenIds in each pool's NAV position list
- Add a regression test covering duplicate TokenId input

## Motivation
computeNAV already validates malformed position lists by rejecting zero balances and mismatched leg counts. This adds the same validation for duplicate TokenIds so a position cannot be included more than once in managerInput.

## Tests
- forge test --offline --match-path test/PanopticVaultAccountant.t.sol --match-test test_computeNAV_revert_duplicateTokenId
- forge test --offline --match-path test/PanopticVaultAccountant.t.sol
- forge build --offline
- npx prettier --check src/accountants/PanopticVaultAccountant.sol test/PanopticVaultAccountant.t.sol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation in vault accounting calculations to detect and reject duplicate position entries within the same pool, preventing incorrect position list errors and improving data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->